### PR TITLE
Fix setup.py rpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,9 @@ class getPybindInclude(object):
         return pybind11.get_include(self.user)
 
 
-extra_compile_args = ["--std=c++11", "-fPIC", "-v", "-O3", "-shared"]
-extra_link_args = ["-rpath,."]
+extra_compile_args = ["--std=c++11", "-fPIC", "-v", "-O3", "-shared", "-Landor"]
+extra_link_args = ["-Wl,-rpath,."]
+
 includes = [getPybindInclude(), getPybindInclude(user=True)]
 
 if sys.platform == "darwin":


### PR DESCRIPTION
Fixes the `extra_link_args` that I think was preventing the shared object to be compiled even when you had all the libraries,

I tested it and the package can be pip installed without the andor libraries and without errors. It doesn't throw any warnings though.