### PR TITLE
Modify debug environment to allow local debugging and OSx debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 node_modules
+
+# Ignore data folder if debugging
+data/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Andor wrapper for Evora and Flask server.
 
 ## Installation
 
-`evora-server` requires the proprietary Andor libraries to be installed in `/usr/local/lib`. The library can be used for debugging without the Andor libraries, but they are necessary to run the actual camera. To run the server in debug mode, with the dummy module mocking the camera, edit `evora/debug.py` and set `DEBUGGING = True`. This will create a folder in the `evora-server` root that acts as the `/data` folder.
+`evora-server` requires the proprietary Andor libraries to be installed in `/usr/local/lib`. The library can be used for debugging without the Andor libraries, but they are necessary to run the actual camera. 
 
 To install `evora-server`, clone the repository and run
 
@@ -17,6 +17,10 @@ or to install in editable mode
 ```console
 pip install -e .
 ```
+
+### Debug mode
+
+To run the server in debug mode, with the dummy module mocking the camera, edit `evora/debug.py` and set `DEBUGGING = True`. This will create a folder in the `evora-server` root that acts as the `/data` folder.
 
 ## Running the server
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Andor wrapper for Evora and Flask server.
 
 ## Installation
 
-`evora-server` requires the proprietary Andor libraries to be installed in `/usr/local/lib`. The library can be used for debugging without the Andor libraries, but they are necessary to run the actual camera. To run the server in debug mode, with the dummy module mocking the camera, edit `debug.py` and set `DEBUGGING = True`.
+`evora-server` requires the proprietary Andor libraries to be installed in `/usr/local/lib`. The library can be used for debugging without the Andor libraries, but they are necessary to run the actual camera. To run the server in debug mode, with the dummy module mocking the camera, edit `evora/debug.py` and set `DEBUGGING = True`. This will create a folder in the `evora-server` root that acts as the `/data` folder.
 
 To install `evora-server`, clone the repository and run
 
@@ -32,13 +32,13 @@ which is equivalent to
 flask --debug run --port 3000
 ```
 
-
-
 ## Images
 
 `evora-server` will save camera files to `/data/ecam/DATE` where `DATE` is in the format `20230504` and rotates at midnight UTC.
 
 If `/data/ecam` does not exist, create it with `mkdir -p` and make sure it has the right permissions for `evora-server` to write to it.
+
+**Note**: Mac OSx doesn't allow the creation of folders in the root `/` directory, since [OSx makes the root directory read-only by default](https://apple.stackexchange.com/questions/388236/unable-to-create-folder-in-root-of-macintosh-hd).
 
 ## Deploying for production
 

--- a/andor_routines.py
+++ b/andor_routines.py
@@ -1,4 +1,4 @@
-from debug import DEBUGGING
+from evora.debug import DEBUGGING
 
 if DEBUGGING:
     from evora.dummy import Dummy as andor

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from flask import (
 from flask_cors import CORS
 
 from andor_routines import acquisition, activateCooling, deactivateCooling, startup
-from debug import DEBUGGING
+from evora.debug import DEBUGGING
 
 if DEBUGGING:
     from evora.dummy import Dummy as andor  # andor
@@ -42,6 +42,11 @@ FILTER_DICT = {'Ha': 0, 'B': 1, 'V': 2, 'g': 3, 'r': 4, 'i': 5}
 FILTER_DICT_REVERSE = {0: 'Ha', 1: 'B', 2: 'V', 3: 'g', 4: 'r', 5: 'i'}
 
 DEFAULT_PATH = '/data/ecam'
+
+# If we're debugging, use a local directory instead - create if doesn't exist
+if DEBUGGING:
+    DEFAULT_PATH = './' + DEFAULT_PATH
+    os.makedirs(os.path.dirname(DEFAULT_PATH), exist_ok=True)
 
 DUMMY_FILTER_POSITION = 0
 

--- a/debug.py
+++ b/debug.py
@@ -1,1 +1,0 @@
-DEBUGGING = False

--- a/evora/debug.py
+++ b/evora/debug.py
@@ -1,0 +1,1 @@
+DEBUGGING = True

--- a/framing/settings.py
+++ b/framing/settings.py
@@ -1,2 +1,9 @@
+import os
+from evora.debug import DEBUGGING
+
 MAX_SOURCES = 50
 CACHE_DIR = "/data/astrometry-index"
+
+if DEBUGGING:
+    CACHE_DIR = './' + CACHE_DIR
+    os.makedirs(os.path.dirname(CACHE_DIR), exist_ok=True)


### PR DESCRIPTION
Modified the debug environment to create a local data directory instead of a root directory. 

- If `DEBUGGING=True`, creates `./data/ecam` and `./data/astrometry-index` and uses it as the mock location.
- Moved `debug.py` to `evora/debug.py` to allow it to be imported program-wide, `from evora.debug import DEBUGGING`. We could use a envfile as well, or set up an `__init__.py` file in the project root, but this felt like the easiest solution. 
    - Modified `app.py`, `andor_routines.py` and `framing/settings.py` to accommodate for this
    - Created a subheader for Debug in README.

Note that OSx doesn't allow creation of files in the root directory by default, so this also allows OSx systems to run the debug environment. 