### PR TITLE
Add script to run in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ If `/data/ecam` does not exist, create it with `mkdir -p` and make sure it has t
 
 ## Deploying for production
 
-The recommended way to deploy `evora-server` is behind a [gunicorn](https://gunicorn.org) web server. To run the Flask webapp from `gunicorn`, execute
-
-```console
-gunicorn -w 1 'app:app'
-```
-
-which will spin a web server with one worker. Currently the app is limited to run with one single worker since the connection to the camera cannot be shared.
+The recommended way to run `evora-server` in production is by running the app with the Flask development server with a single process and threading. This allows for concurrent routes and asyncio to work (which is required for features such as aborting exposures). At this point this is preferred to using a UWSGI layer such as `gunicorn` since the camera has a single connection so we cannot run multiple workers.
 
 To run this command in the background as a systemd service, create a file `/etc/systemd/system/evora-server.service` with the contents
 
@@ -58,13 +52,13 @@ Description=evora-server
 
 [Service]
 WorkingDirectory=/home/mrouser/Github/evora-server
-ExecStart=/home/mrouser/Github/evora-server/gunicorn-start.sh
+ExecStart=/home/mrouser/Github/evora-server/standalone-start.sh
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-Here we are pointing to the file `gunicorn-start.sh` in the repo, which loads the conda environment and starts gunicorn. This may need to be changed for a location other than MRO. Then start the systemd service with
+Here we are pointing to the file `standalone-start.sh` in the repo, which loads the conda environment and starts the server in production mode (port 8000, threading, one worker). This may need to be changed for a location other than MRO. Then start the systemd service with
 
 ```console
 sudo systemctl daemon-reload
@@ -74,7 +68,7 @@ sudo systemctl restart evora-server
 
 ### Configuring nginx
 
-In addition to `gunicorn`, a reverse proxy is needed to run the Evora client and server in the same web server. In Ubuntu, install `nginx` (alternatively you can use `Apache`) with
+In addition to running the server, a reverse proxy is needed to run the Evora client and server in the same HTTP server. In Ubuntu, install `nginx` (alternatively you can use `Apache`) with
 
 ```console
 sudo apt update
@@ -118,7 +112,7 @@ server {
 }
 ```
 
-This configuration creates a server running on port `80` (the default HTTP) and adds a reverse proxy to where `gunicorn` is running the Flask webapp. Note that we allow requests to the API to take as much as 30 minutes (which should be enough for most exposure times). It also creates a route to expose and browse `/data`.
+This configuration creates a server running on port `80` (the default HTTP) and adds a reverse proxy to where the `evora-server` webapp is running. It also creates a route to expose and browse `/data`.
 
 After this, restart `nginx` with
 

--- a/app.py
+++ b/app.py
@@ -271,7 +271,7 @@ def create_app(test_config=None):
                 elapsed += 0.1
                 if elapsed >= float(req["exptime"]) + 0.5:
                     break
-            
+
             if ABORT_FLAG:
                 andor.abortAcquisition()
                 return {'message': str('Capture aborted'), 'status': 1}
@@ -355,7 +355,7 @@ def create_app(test_config=None):
         '''Returns the position of the filter wheel.'''
         if DEBUGGING:
             return jsonify({'success': True, 'filter': FILTER_DICT_REVERSE[DUMMY_FILTER_POSITION], 'error': ''})
-        
+
         status, reply = await send_to_wheel('get')
         filter_name = None
         error = ''
@@ -461,6 +461,8 @@ import focus
 focus.register_blueprint(app)
 
 if __name__ == '__main__':
+    # TO RUN IN PRODUCTION, USE:
+    # app.run(host='127.0.0.1', port=8000, debug=False, threaded=True, processes=1)
+
     # FOR DEBUGGING, USE:
-    # app.run(host='127.0.0.1', port=8000, debug=True, processes=1)
-    app.run(host='127.0.0.1', port=3000, debug=True, processes=1)
+    app.run(host='127.0.0.1', port=3000, debug=True, processes=1, threaded=True)

--- a/app.py
+++ b/app.py
@@ -462,6 +462,9 @@ focus.register_blueprint(app)
 
 if __name__ == '__main__':
     # TO RUN IN PRODUCTION, USE:
+    # The key here is threaded=True which allows the server to handle multiple
+    # requests at once but withing a single process (?), which allows sharing the
+    # camera connection.
     # app.run(host='127.0.0.1', port=8000, debug=False, threaded=True, processes=1)
 
     # FOR DEBUGGING, USE:

--- a/standalone-start.sh
+++ b/standalone-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Runs the camera server as a single worker without threading.
+# This allows for concurrency and async.
+source /home/mrouser/anaconda3/etc/profile.d/conda.sh
+conda activate uwmro_instruments
+flask --no-debug run -p 8000 -h 127.0.0.1 --with-threads --no-debugger --no-reload


### PR DESCRIPTION
This PR adds a script `standalone-start.sh` which runs the app using Flask's development mode but with a single worker and threaded enabled. This allows for actual concurrency and multiple routes to run simultaneously.

`gunicorn` enables concurrency by setting multiple workers, but doesn't effectively allow the use of `asyncio`. Since we are limited to one worker becuase of the camera one connection, there isn't much difference between `gunicorn` and just running Flask directly (probably?) and the latter allows for features such as aborting an exposure.