### PR TITLE
Instructions & config for `evora-server` to be run on a new repo clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,25 @@ flask --debug run --port 3000
 
 `evora-server` will save camera files to `/data/ecam/DATE` where `DATE` is in the format `20230504` and rotates at midnight UTC.
 
-If `/data/ecam` does not exist, create it with `mkdir -p` and make sure it has the right permissions for `evora-server` to write to it.
-
 **Note**: Mac OSx doesn't allow the creation of folders in the root `/` directory, since [OSx makes the root directory read-only by default](https://apple.stackexchange.com/questions/388236/unable-to-create-folder-in-root-of-macintosh-hd).
 
 ## Deploying for production
 
 The recommended way to run `evora-server` in production is by running the app with the Flask development server with a single process and threading. This allows for concurrent routes and asyncio to work (which is required for features such as aborting exposures). At this point this is preferred to using a UWSGI layer such as `gunicorn` since the camera has a single connection so we cannot run multiple workers.
+
+First, make sure the `/data/ecam` directory exists with the proper user permissions
+
+```console
+sudo mkdir -p /data/ecam && sudo chown -R $USER /data
+```
+
+and that the Andor SDK is installed with
+
+```console
+ls /usr/local/lib/libandor.so
+```
+
+Try to run `standalone-start.sh` in the `evora-server` now. It should start downloading around ~20 GB of data for astrometry. Once this is done, you should see the server spin up. 
 
 To run this command in the background as a systemd service, create a file `/etc/systemd/system/evora-server.service` with the contents
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ and that the Andor SDK is installed with
 ls /usr/local/lib/libandor.so
 ```
 
-Try to run `standalone-start.sh` in the `evora-server` now. It should start downloading around ~20 GB of data for astrometry. Once this is done, you should see the server spin up. 
+Try to run `standalone-start.sh` in the `evora-server` now. It should start downloading around ~20 GB of data for astrometry. Once this is done, you should see the server spin up (ignore the "This is a development server" warning). Test it with `curl localhost:8000/getStatus`.
 
-To run this command in the background as a systemd service, create a file `/etc/systemd/system/evora-server.service` with the contents
+To run this command in the background as a user `systemd` service, create a file `/usr/lib/systemd/user/evora-server.service` with the contents
 
 ```ini
 [Unit]
@@ -71,15 +71,15 @@ WorkingDirectory=/home/mrouser/Github/evora-server
 ExecStart=/home/mrouser/Github/evora-server/standalone-start.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
-Here we are pointing to the file `standalone-start.sh` in the repo, which loads the conda environment and starts the server in production mode (port 8000, threading, one worker). This may need to be changed for a location other than MRO. Then start the systemd service with
+Change `WorkingDirectory` and `ExecStart` to the download location of `evora-server`, then run the following commands to get it to run at system start.
 
 ```console
-sudo systemctl daemon-reload
-sudo systemctl enable --now enable evora-server
-sudo systemctl restart evora-server
+systemctl --user daemon-reload
+systemctl --user enable --now enable evora-server
+systemctl --user status evora-server
 ```
 
 ### Configuring nginx

--- a/app.py
+++ b/app.py
@@ -36,6 +36,8 @@ else:
  this is for handling requests from the filter wheel that may take some time.
 '''
 
+# add instructions to create data dir
+
 logging.getLogger('PIL').setLevel(logging.WARNING)
 
 FILTER_DICT = {'Ha': 0, 'B': 1, 'V': 2, 'g': 3, 'r': 4, 'i': 5}

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ext_modules = [
     )
 ]
 
-# Works with Python 3.10.0 - numpy.dtype sizes changes with 2, causing issues with sep
+# Works with Python 3.13.0
 setup(
     name="evora",
     version="0.2.2a0",
@@ -59,7 +59,7 @@ setup(
     author="Astronomy Undergraduate Engineering Group",
     setup_requires=["pybind11"],
     install_requires=[
-        "numpy<2",
+        "numpy",
         "astropy>=4.0",
         "pillow",
         "flask[async]",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ext_modules = [
     )
 ]
 
-# Works with Python 3.10.0
+# Works with Python 3.10.0 - numpy.dtype sizes changes with 2, causing issues with sep
 setup(
     name="evora",
     version="0.2.2a0",
@@ -59,7 +59,7 @@ setup(
     author="Astronomy Undergraduate Engineering Group",
     setup_requires=["pybind11"],
     install_requires=[
-        "numpy",
+        "numpy<2",
         "astropy>=4.0",
         "pillow",
         "flask[async]",

--- a/standalone-start.sh
+++ b/standalone-start.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
 
+# Get the working directory of evora-server and go to it
+EVORA_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $EVORA_DIR
+
+# Check for the existence of a virtual environment
+if ! [ -d ".venv" ]; then
+    # If it doesn't exist - create it
+    /usr/bin/python -m venv init .venv
+
+    # ... start the venv
+    source .venv/bin/activate
+
+    # ... and install packages within
+    pip install .
+else
+    # start the venv
+    source .venv/bin/activate
+fi
+
 # Runs the camera server as a single worker without threading.
-# This allows for concurrency and async.
-source /home/mrouser/anaconda3/etc/profile.d/conda.sh
-conda activate uwmro_instruments
+# This allows for concurrency and async - redo to run app.py with port, host, debugger
 flask --no-debug run -p 8000 -h 127.0.0.1 --with-threads --no-debugger --no-reload

--- a/standalone-start.sh
+++ b/standalone-start.sh
@@ -13,7 +13,7 @@ if ! [ -d ".venv" ]; then
     source .venv/bin/activate
 
     # ... and install packages within
-    pip install .
+    pip install -e .
 else
     # start the venv
     source .venv/bin/activate


### PR DESCRIPTION
It looks like the instructions for  a fresh `evora-server` installation were a bit out of date, so José and I gave it a bit of a refresh. This should allow us to deploy `evora-server` fresh onto new machines, assuming Andor SDK 2 is installed. 

Some things to note:

1. We need to use an old version of `numpy<2` to allow `sep` to work properly - updated accordingly in `setup.py`.
2. Rewrote our README to give instructions for a *user* runtime of `evora-server` - it should now no longer be operating with root permissions, which is much safer from a webapp security standpoint (even on a somewhat isolated network).
3. Switched over from an `anaconda` pip setup to a `virtualenv` setup. Python comes default with `venv` on (most) Linux installations, and it's much more lightweight. Configured `standalone-start.sh` to create this on a first run, and reuse it on subsequent runs.